### PR TITLE
Update notebook for Holo1.5 and Holo2 to include baseurls and models

### DIFF
--- a/holo1_5/openai_client/invoke_localization.ipynb
+++ b/holo1_5/openai_client/invoke_localization.ipynb
@@ -229,6 +229,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**API configuration**\n",
+    "\n",
+    "Here are the relevant URLs and names to use when configuring the API for Holo:\n",
+    "\n",
+    "\n",
+    "\n",
+    "*Example variables*\n",
+    "\n",
+    "- MODEL_NAME = holo1-5-3b-20250915\n",
+    "\n",
+    "- API_BASE_URL = https://api.hcompanyprod.fr/v1/models\n",
+    "\n",
+    "\n",
+    "*Available models*\n",
+    "\n",
+    "- holo1-5-7b-20250915\n",
+    "- holo1-5-3b-20250915"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Invoke model"
    ]
   },

--- a/holo2/holo_2_localization_hosted_api.ipynb
+++ b/holo2/holo_2_localization_hosted_api.ipynb
@@ -213,6 +213,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**API configuration**\n",
+    "\n",
+    "Here are the relevant URLs and names to use when configuring the API for Holo:\n",
+    "\n",
+    "\n",
+    "\n",
+    "*Example variables*\n",
+    "\n",
+    "- MODEL_NAME = holo2-4b-20251115\n",
+    "\n",
+    "- API_BASE_URL = https://api.hcompanyprod.fr/v1/models\n",
+    "\n",
+    "\n",
+    "*Available models*\n",
+    "\n",
+    "- holo2-4b-20251115\n",
+    "- holo2-8b-20251115"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Invoke model"
    ]
   },


### PR DESCRIPTION
Instructions now include baseurl and available models in prod